### PR TITLE
[ci] run on 8.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   # - COQ_VERSION="8.6"
   - COQ_VERSION="8.7"
   - COQ_VERSION="8.8"
-  # - COQ_VERSION="8.9"
+  - COQ_VERSION="8.9"
   - COQ_VERSION="dev"
 
 install: |


### PR DESCRIPTION
8.9 is released, and the CI file already included a line for that. I've just uncommented it.