### PR TITLE
Update the "opam switch" command & Add missing quoting backslashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   global:
   - NJOBS="2"
   - CONTRIB_NAME="fourcolor"
-  - OPAM_SWITCH="4.07.0+flambda"
   - MATHCOMP_VERSION=":1.7.0-"
   matrix:
   # - COQ_VERSION="8.6"
@@ -31,8 +30,8 @@ install: |
     set -ex  # -e = exit on failure; -x = trace for debug
     # Using flambda makes sense here as we usually get ~10% faster
     # builds in math-comp.
-    opam switch set "$OPAM_SWITCH"
-    eval $(opam env)
+    opam switch \$COMPILER_EDGE
+    eval \$(opam env)
     opam update -y
     opam config list
     opam repo list
@@ -45,7 +44,7 @@ script:
     export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
     set -ex
     sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
-    eval $(opam env)
+    eval \$(opam env)
     make -j "$NJOBS"
     make install
     "

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
   - NJOBS="2"
   - CONTRIB_NAME="fourcolor"
-  - MATHCOMP_VERSION=":1.7.0-"
+  - MATHCOMP_VERSION=":1.8.0-"
   matrix:
   # - COQ_VERSION="8.6"
   - COQ_VERSION="8.7"


### PR DESCRIPTION
This patch is a backward-compatible fix for the opam switch upgrade in
coqorg/coq:dev (now 4.07.1+flambda), which is about to be propagated
to mathcomp Docker images (see also math-comp/docker-mathcomp#3)

This PR also replaces the mathcomp version with 1.8.0, as 1.7.0 is not compatible with coq.dev anymore.