### PR TITLE
suppress use of `Arith` hints

### DIFF
--- a/theories/part.v
+++ b/theories/part.v
@@ -617,9 +617,9 @@ Definition mirror_part p := mirror_part_rec (get_hat p) Pnil p.
 
 Lemma size_mirror_part p : size_part (mirror_part p) = size_part p.
 Proof.
-rewrite /mirror_part -[size_part p]/(size_part Pnil + size_part p).
+rewrite /mirror_part -[RHS]addn0 -[0]/(size_part Pnil).
 elim: p Pnil (get_hat p) => //= [s h|h f1|h f1 f2|h f1 f2 f3] p IHp q h0;
-  by rewrite ?addn0 ?addnS ?IHp.
+  by rewrite IHp !addnS.
 Qed.
 
 Lemma mirror_mirror_part p : mirror_part (mirror_part p) = p.

--- a/theories/walkup.v
+++ b/theories/walkup.v
@@ -435,7 +435,7 @@ rewrite -addSn -fcard_skip_edge -(fcard_skip faceI) -(fcard_skip nodeI).
 rewrite [t in _ + _ + t]addnACA addnACA /n_comp_z z_barb_z; congr (_ + _).
 rewrite /glink /=; case ez_z: (ez == z).
   by rewrite (canF_eq nodeK) (eqP ez_z) eq_sym andbb addnn.
-have [nz_z | _] /= := nz =P z; last by case: ifP.
+  have [nz_z | _] /= := nz =P z; last by rewrite addnC; case: ifP.
 by rewrite (canF_eq faceK) eq_sym nz_z ez_z.
 Qed.
 


### PR DESCRIPTION
Ensure `by ...` does not invoke arithmetic hints from the Coq prelude.