### PR TITLE
patch for the long_short_suffixes PR 473 of mathcomp

### DIFF
--- a/theories/color.v
+++ b/theories/color.v
@@ -465,7 +465,7 @@ Proof.
 elim: n => [|n IHn]; first by rewrite !rot0.
 have [le_le_c | lt_n_le] := leqP (size lc) n.
   by rewrite !rot_oversize ?size_trace // ltnW.
-by rewrite -add1n !rot_addn ?size_trace // -IHn -!urtrace_trace -urtrace_rot.
+by rewrite -add1n !rotD ?size_trace // -IHn -!urtrace_trace -urtrace_rot.
 Qed.
 
 Lemma trace_rev (lc : colseq) : trace (rev lc) = rot 1 (rev (trace lc)).

--- a/theories/kempetree.v
+++ b/theories/kempetree.v
@@ -382,7 +382,7 @@ have -> /=: even_trace (pre (etrace et)).
     by apply: (congr1 even_tail (eq_map _ _)); case e => [] [].
 rewrite -[n in dyck n]odd_double_half -lt0n.
 have -> et': odd (count_cbit1 et') = cbit1 (sumt et').
-  by elim: et' => //= c et' IHet'; rewrite odd_add IHet' cbit1_addc; case c.
+  by elim: et' => //= c et' IHet'; rewrite oddD IHet' cbit1_addc; case c.
 by rewrite !sumt_permt sumt_ctrace !permc0 even_dyck_pos.
 Qed.
 
@@ -421,4 +421,3 @@ split=> //; exists (g \o k); first exact: coloring_inj (@permc_inj g) col_k.
 rewrite map_comp trace_permt sumt_permt.
 by rewrite -[trace _](rotK 1) -trace_rot -map_rot -Det1 rotr1_rcons.
 Qed.
-


### PR DESCRIPTION
`rot_addn`, `odd_add` have become `rotD`, `oddD` with mathcomp 1.11.0+beta1