### PR TITLE
[opam] simplify pinning local opam file

### DIFF
--- a/opam
+++ b/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "coq-mathcomp-fourcolor"
+name: "coq-fourcolor"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 homepage: "https://math-comp.github.io/math-comp/"
@@ -9,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
-depends: [ "coq-mathcomp-algebra" { = "dev" } ]
+depends: [ "coq-mathcomp-algebra" { >= "1.11.0" | = "dev" } ]
 
 tags: [ "keyword:Four color theorem" "keyword:small scale reflection" "keyword:mathematical components" ]
 authors: [ "Georges Gonthier" ]


### PR DESCRIPTION
This PR fixes two minor inconveniences when trying to to pin the `opam` file:

1. It aligns the `name` field with the package name in the opam-coq-archive.
2. It allows building against (stable) releases that are not known to cause build failures. Currently, this is only `mathcomp-1.11` 

The ` | = "dev"` is technically redundant but serves as a reminder that "dev" should always be part of the version range (for CI). This follows the dependency specification for the [odd-order](https://github.com/math-comp/odd-order/blob/6a68aaf71f22eb2d5b13043f5edad40ea9836844/coq-mathcomp-odd-order.opam#L15) development. 