### PR TITLE
make Require Imports idiomatic

### DIFF
--- a/theories/approx.v
+++ b/theories/approx.v
@@ -1,17 +1,12 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype tuple.
-From mathcomp
-Require Import path fingraph bigop order ssralg ssrnum ssrint div intdiv.
-From fourcolor
-Require Import hypermap geometry coloring grid matte.
-From fourcolor
-Require Import real realplane.
-Require Import Setoid Morphisms.
-From fourcolor
-Require Import realsyntax realprop.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype tuple path fingraph bigop order ssralg.
+From mathcomp Require Import ssrnum ssrint div intdiv.
+From fourcolor Require Import hypermap geometry coloring grid matte.
+From fourcolor Require Import real realplane.
+From Coq Require Import Setoid Morphisms.
+From fourcolor Require Import realsyntax realprop.
 
 (******************************************************************************)
 (*   Approximations of real scalars, points, regions and rectangles, used to  *)

--- a/theories/birkhoff.v
+++ b/theories/birkhoff.v
@@ -1,16 +1,11 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap jordan geometry color chromogram coloring patch snip.
-From fourcolor
-Require Import sew revsnip kempe.
-From fourcolor
-Require Import ctree initctree gtree initgtree ctreerestrict gtreerestrict.
-From fourcolor
-Require Import cfmap cfcolor kempetree.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap jordan geometry color chromogram.
+From fourcolor Require Import coloring patch snip sew revsnip kempe.
+From fourcolor Require Import ctree initctree gtree initgtree ctreerestrict.
+From fourcolor Require Import gtreerestrict cfmap cfcolor kempetree.
 
 (******************************************************************************)
 (* The Birkhoff theorem, stating that a minimal coloring counter-example must *)

--- a/theories/cfcolor.v
+++ b/theories/cfcolor.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color coloring cfmap ctree.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color coloring cfmap ctree.
 
 (******************************************************************************)
 (*   Compute the set of colorings of a configuration ring, directly from the  *)

--- a/theories/cfcontract.v
+++ b/theories/cfcontract.v
@@ -1,10 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color coloring cfmap ctree cfcolor.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color coloring cfmap ctree.
+From fourcolor Require Import cfcolor.
 
 (******************************************************************************)
 (*   Compute the contract of a configuration construction: a cprog whose ring *)

--- a/theories/cfmap.v
+++ b/theories/cfmap.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color.
 
 (******************************************************************************)
 (*   Configuration maps are entered as little linear construction programs:   *)

--- a/theories/cfquiz.v
+++ b/theories/cfquiz.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color coloring patch cfmap quiz.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color coloring patch cfmap quiz.
 
 (******************************************************************************)
 (* Compile the quiz that tests for the occurrence of a configuration. Since   *)

--- a/theories/cfreducible.v
+++ b/theories/cfreducible.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color chromogram coloring kempe.
-From fourcolor
-Require Import cfmap cfcolor cfcontract ctree kempetree.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color chromogram coloring kempe.
+From fourcolor Require Import cfmap cfcolor cfcontract ctree kempetree.
 
 (******************************************************************************)
 (*   The reducibility decision procedure; we only use C-reductibility, as the *)

--- a/theories/chromogram.v
+++ b/theories/chromogram.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
-From fourcolor
-Require Import color.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype.
+From fourcolor Require Import color.
 
 (******************************************************************************)
 (*   Chromograms are words representing congruence classes of regions with    *)

--- a/theories/color.v
+++ b/theories/color.v
@@ -1,8 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype.
 
 (******************************************************************************)
 (* The four colors, with color sum (xor) and comparison:                      *)

--- a/theories/coloring.v
+++ b/theories/coloring.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap walkup geometry color chromogram.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap walkup geometry color chromogram.
 
 (******************************************************************************)
 (* Hypermap, graph and contract colorings, colorable maps, ring traces, valid *)

--- a/theories/combinatorial4ct.v
+++ b/theories/combinatorial4ct.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color coloring cube present.
-From fourcolor
-Require Import unavoidability reducibility.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color coloring cube present.
+From fourcolor Require Import unavoidability reducibility.
 
 (******************************************************************************)
 (*   The (constructive) proof of the Four Color Theorem for finite            *)

--- a/theories/configurations.v
+++ b/theories/configurations.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap.
 
 (******************************************************************************)
 (*   The construction programs for the 633 reducible configurations, using    *)

--- a/theories/contract.v
+++ b/theories/contract.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap walkup geometry color coloring patch snip revsnip.
-From fourcolor
-Require Import birkhoff.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap walkup geometry color coloring patch.
+From fourcolor Require Import snip revsnip birkhoff.
 
 (******************************************************************************)
 (* The proof that there exists a contract coloring for any valid contract.    *)

--- a/theories/ctree.v
+++ b/theories/ctree.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq.
-From fourcolor
-Require Import color.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From fourcolor Require Import color.
 
 (******************************************************************************)
 (*   Sets of ring coloring traces are represented by a ternary tree structure *)

--- a/theories/ctreerestrict.v
+++ b/theories/ctreerestrict.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq.
-From fourcolor
-Require Import color chromogram gtree ctree.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From fourcolor Require Import color chromogram gtree ctree.
 
 (******************************************************************************)
 (* This is the second phase of a D-reducibility step: adjusting the coloring  *)

--- a/theories/cube.v
+++ b/theories/cube.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color coloring.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color coloring.
 
 (******************************************************************************)
 (*   Reduction of the coloring problem to cubic maps; since this is not the   *)

--- a/theories/dedekind.v
+++ b/theories/dedekind.v
@@ -1,11 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq order ssralg ssrnum ssrint rat.
-From fourcolor
-Require Import real.
-Require Import Setoid Morphisms.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq order.
+From mathcomp Require Import ssralg ssrnum ssrint rat.
+From fourcolor Require Import real.
+From Coq Require Import Setoid Morphisms.
 
 (******************************************************************************)
 (*   Construcion of the real numbers as a complete totally ordered field.     *)

--- a/theories/discharge.v
+++ b/theories/discharge.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From mathcomp
-Require Import bigop order ssralg ssrnum ssrint.
-From fourcolor
-Require Import hypermap geometry part.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From mathcomp Require Import bigop order ssralg ssrnum ssrint.
+From fourcolor Require Import hypermap geometry part.
 
 (******************************************************************************)
 (* Discharging arities to neighbouring faces. We specify how to compute the   *)

--- a/theories/discretize.v
+++ b/theories/discretize.v
@@ -1,14 +1,10 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From mathcomp
-Require Import bigop ssralg ssrnum ssrint div intdiv.
-From fourcolor
-Require Import hypermap geometry coloring grid matte gridmap.
-From fourcolor
-Require Import real realplane realprop approx.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph bigop ssralg ssrnum ssrint.
+From mathcomp Require Import div intdiv.
+From fourcolor Require Import hypermap geometry coloring grid matte gridmap.
+From fourcolor Require Import real realplane realprop approx.
 
 (******************************************************************************)
 (* Discretizing the coloring problem for an arbitrary finite map. We compute  *)

--- a/theories/dyck.v
+++ b/theories/dyck.v
@@ -1,8 +1,6 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat.
 
 (******************************************************************************)
 (* We define two combinatorial functions:                                     *)

--- a/theories/embed.v
+++ b/theories/embed.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color chromogram coloring patch snip revsnip.
-From fourcolor
-Require Import kempe birkhoff contract.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color chromogram coloring patch.
+From fourcolor Require Import snip revsnip kempe birkhoff contract.
 
 (******************************************************************************)
 (*   This is the crux of the Four Color Theorem proof: we build an injective  *)

--- a/theories/finitize.v
+++ b/theories/finitize.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice path ssralg ssrint.
-From fourcolor
-Require Import real realplane realsyntax realprop.
-From fourcolor
-Require Import grid approx.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import path ssralg ssrint.
+From fourcolor Require Import real realplane realsyntax realprop.
+From fourcolor Require Import grid approx.
 
 (******************************************************************************)
 (*   We use a special case of the compactness theorem for predicate logic to  *)

--- a/theories/fourcolor.v
+++ b/theories/fourcolor.v
@@ -1,9 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-From fourcolor
-Require Import real realplane.
-From fourcolor
-Require combinatorial4ct discretize finitize.
+From fourcolor Require Import real realplane.
+From fourcolor Require combinatorial4ct discretize finitize.
 
 (******************************************************************************)
 (*   This files contains the proof of the high-level statement of the Four    *)

--- a/theories/geometry.v
+++ b/theories/geometry.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap jordan.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap jordan.
 
 (******************************************************************************)
 (* The geometrical interpretation of hypermap, the definition of most of the  *)

--- a/theories/grid.v
+++ b/theories/grid.v
@@ -1,12 +1,8 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq path div choice order.
-From mathcomp
-Require Import ssralg ssrnum ssrint intdiv.
-From fourcolor
-Require Import hypermap.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice order ssralg ssrnum ssrint intdiv.
+From fourcolor Require Import hypermap.
 
 (******************************************************************************)
 (*    Geometry over an integer grid, that is, raster graphics.                *)

--- a/theories/gridmap.v
+++ b/theories/gridmap.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From mathcomp
-Require Import order ssralg ssrnum ssrint.
-From fourcolor
-Require Import hypermap geometry color coloring patch snip grid matte.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph order ssralg ssrnum ssrint.
+From fourcolor Require Import hypermap geometry color coloring patch snip grid.
+From fourcolor Require Import matte.
 
 (******************************************************************************)
 (* The construction of a hypermap, from a finite set of disjoint mattes and a *)

--- a/theories/gtree.v
+++ b/theories/gtree.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq.
-From fourcolor
-Require Import color chromogram.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From fourcolor Require Import color chromogram.
 
 (******************************************************************************)
 (*   Sets of partial chromograms are stored as 4-way trees, much like partial *)

--- a/theories/gtreerestrict.v
+++ b/theories/gtreerestrict.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq.
-From fourcolor
-Require Import color ctree chromogram gtree.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From fourcolor Require Import color ctree chromogram gtree.
 
 (******************************************************************************)
 (* This is the first phase of a D-reducibility step: removing from the set of *)

--- a/theories/hubcap.v
+++ b/theories/hubcap.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From mathcomp
-Require Import bigop order ssralg ssrnum ssrint.
-From fourcolor
-Require Import hypermap geometry quiztree part discharge.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From mathcomp Require Import bigop order ssralg ssrnum ssrint.
+From fourcolor Require Import hypermap geometry quiztree part discharge.
 
 (******************************************************************************)
 (* Ruling out a part using a combination of discharging and reducibility.     *)

--- a/theories/hypermap.v
+++ b/theories/hypermap.v
@@ -1,8 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import choice fintype path fingraph.
 
 (******************************************************************************)
 (*   A (finite) hypermap is just a triplet of functions over a finite type,   *)

--- a/theories/initctree.v
+++ b/theories/initctree.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq.
-From fourcolor
-Require Import color ctree dyck.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From fourcolor Require Import color ctree dyck.
 
 (******************************************************************************)
 (*   Creation of an initial (full) coloring tree and its correctness theorem. *)

--- a/theories/initgtree.v
+++ b/theories/initgtree.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq.
-From fourcolor
-Require Import color chromogram gtree dyck.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From fourcolor Require Import color chromogram gtree dyck.
 
 (******************************************************************************)
 (*   Creation of the initial (full) chromogram tree for a given ring size     *)

--- a/theories/job001to106.v
+++ b/theories/job001to106.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 1 to 106, whose indices in           *)

--- a/theories/job107to164.v
+++ b/theories/job107to164.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 107 to 164, whose indices in         *)

--- a/theories/job165to189.v
+++ b/theories/job165to189.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 165 to 189, whose indices in         *)

--- a/theories/job190to206.v
+++ b/theories/job190to206.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 190 to 206, whose indices in         *)

--- a/theories/job207to214.v
+++ b/theories/job207to214.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 207 to 214, whose indices in         *)

--- a/theories/job215to218.v
+++ b/theories/job215to218.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 215 to 218, whose indices in         *)

--- a/theories/job219to222.v
+++ b/theories/job219to222.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 219 to 222, whose indices in         *)

--- a/theories/job223to226.v
+++ b/theories/job223to226.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 223 to 226, whose indices in         *)

--- a/theories/job227to230.v
+++ b/theories/job227to230.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 227 to 230, whose indices in         *)

--- a/theories/job231to234.v
+++ b/theories/job231to234.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 231 to 234, whose indices in         *)

--- a/theories/job235to238.v
+++ b/theories/job235to238.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 235 to 238, whose indices in         *)

--- a/theories/job239to253.v
+++ b/theories/job239to253.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 239 to 253, whose indices in         *)

--- a/theories/job254to270.v
+++ b/theories/job254to270.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 254 to 270, whose indices in         *)

--- a/theories/job271to278.v
+++ b/theories/job271to278.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 271 to 278, whose indices in         *)

--- a/theories/job279to282.v
+++ b/theories/job279to282.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 279 to 282, whose indices in         *)

--- a/theories/job283to286.v
+++ b/theories/job283to286.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 283 to 286, whose indices in         *)

--- a/theories/job287to290.v
+++ b/theories/job287to290.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 287 to 290, whose indices in         *)

--- a/theories/job291to294.v
+++ b/theories/job291to294.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 291 to 294, whose indices in         *)

--- a/theories/job295to298.v
+++ b/theories/job295to298.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 295 to 298, whose indices in         *)

--- a/theories/job299to302.v
+++ b/theories/job299to302.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 299 to 302, whose indices in         *)

--- a/theories/job303to306.v
+++ b/theories/job303to306.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 303 to 306, whose indices in         *)

--- a/theories/job307to310.v
+++ b/theories/job307to310.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 307 to 310, whose indices in         *)

--- a/theories/job311to314.v
+++ b/theories/job311to314.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 311 to 314, whose indices in         *)

--- a/theories/job315to318.v
+++ b/theories/job315to318.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 315 to 318, whose indices in         *)

--- a/theories/job319to322.v
+++ b/theories/job319to322.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 319 to 322, whose indices in         *)

--- a/theories/job323to383.v
+++ b/theories/job323to383.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 323 to 383, whose indices in         *)

--- a/theories/job384to398.v
+++ b/theories/job384to398.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 384 to 398, whose indices in         *)

--- a/theories/job399to438.v
+++ b/theories/job399to438.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 399 to 438, whose indices in         *)

--- a/theories/job439to465.v
+++ b/theories/job439to465.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 439 to 465, whose indices in         *)

--- a/theories/job466to485.v
+++ b/theories/job466to485.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 466 to 485, whose indices in         *)

--- a/theories/job486to489.v
+++ b/theories/job486to489.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 486 to 489, whose indices in         *)

--- a/theories/job490to494.v
+++ b/theories/job490to494.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 490 to 494, whose indices in         *)

--- a/theories/job495to498.v
+++ b/theories/job495to498.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 495 to 498, whose indices in         *)

--- a/theories/job499to502.v
+++ b/theories/job499to502.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 499 to 502, whose indices in         *)

--- a/theories/job503to506.v
+++ b/theories/job503to506.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 503 to 506, whose indices in         *)

--- a/theories/job507to510.v
+++ b/theories/job507to510.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 507 to 510, whose indices in         *)

--- a/theories/job511to516.v
+++ b/theories/job511to516.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 511 to 516, whose indices in         *)

--- a/theories/job517to530.v
+++ b/theories/job517to530.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 517 to 530, whose indices in         *)

--- a/theories/job531to534.v
+++ b/theories/job531to534.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 531 to 534, whose indices in         *)

--- a/theories/job535to541.v
+++ b/theories/job535to541.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 535 to 541, whose indices in         *)

--- a/theories/job542to545.v
+++ b/theories/job542to545.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 542 to 545, whose indices in         *)

--- a/theories/job546to549.v
+++ b/theories/job546to549.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 546 to 549, whose indices in         *)

--- a/theories/job550to553.v
+++ b/theories/job550to553.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 550 to 553, whose indices in         *)

--- a/theories/job554to562.v
+++ b/theories/job554to562.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 554 to 562, whose indices in         *)

--- a/theories/job563to588.v
+++ b/theories/job563to588.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 563 to 588, whose indices in         *)

--- a/theories/job589to610.v
+++ b/theories/job589to610.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 589 to 610, whose indices in         *)

--- a/theories/job611to617.v
+++ b/theories/job611to617.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 611 to 617, whose indices in         *)

--- a/theories/job618to622.v
+++ b/theories/job618to622.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 618 to 622, whose indices in         *)

--- a/theories/job623to633.v
+++ b/theories/job623to633.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
 
 (******************************************************************************)
 (* Reducibility of configurations number 623 to 633, whose indices in         *)

--- a/theories/jordan.v
+++ b/theories/jordan.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap walkup.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap walkup.
 
 (******************************************************************************)
 (* This file proves the validity of our Jordan curve theorem inspired         *)

--- a/theories/kempe.v
+++ b/theories/kempe.v
@@ -1,10 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap walkup jordan geometry color chromogram coloring.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap walkup jordan geometry color chromogram.
+From fourcolor Require Import coloring.
 
 (******************************************************************************)
 (*   The proof of the Kempe closure property of the set of trace colorings of *)

--- a/theories/kempetree.v
+++ b/theories/kempetree.v
@@ -1,12 +1,10 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color chromogram coloring cfmap cfcolor.
-From fourcolor
-Require Import dyck ctree initctree gtree initgtree gtreerestrict ctreerestrict.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color chromogram coloring cfmap.
+From fourcolor Require Import cfcolor dyck ctree initctree gtree initgtree.
+From fourcolor Require Import gtreerestrict ctreerestrict.
 
 (******************************************************************************)
 (*   Here we put all the reducibility steps together, to compute the Kempe    *)

--- a/theories/matte.v
+++ b/theories/matte.v
@@ -1,12 +1,8 @@
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice path order.
-From mathcomp
-Require Import ssralg ssrnum ssrint div intdiv.
-From fourcolor
-Require Import grid.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import path order ssralg ssrnum ssrint div intdiv.
+From fourcolor Require Import grid.
 
 (******************************************************************************)
 (* Mattes are finite sets of grid squares that are delimited by a simple grid *)

--- a/theories/part.v
+++ b/theories/part.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap color geometry.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap color geometry.
 
 (******************************************************************************)
 (*    These "parts" are patterns for performing local matching on maps.       *)

--- a/theories/patch.v
+++ b/theories/patch.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry jordan color coloring.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry jordan color coloring.
 
 (******************************************************************************)
 (*   Patching two maps to cover a larger one. The relations established here  *)

--- a/theories/present.v
+++ b/theories/present.v
@@ -1,16 +1,10 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From mathcomp
-Require Import bigop ssralg ssrnum ssrint.
-From fourcolor
-Require Import hypermap geometry patch coloring birkhoff embed quiz quiztree.
-From fourcolor
-Require Import part redpart discharge hubcap.
-From fourcolor
-Require Import cfmap cfcontract cfreducible configurations.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph bigop ssralg ssrnum ssrint.
+From fourcolor Require Import hypermap geometry patch coloring birkhoff embed.
+From fourcolor Require Import quiz quiztree part redpart discharge hubcap.
+From fourcolor Require Import cfmap cfcontract cfreducible configurations.
 
 (******************************************************************************)
 (*   This file defines the properties and the specialized scripting language  *)

--- a/theories/present10.v
+++ b/theories/present10.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/present11.v
+++ b/theories/present11.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/present5.v
+++ b/theories/present5.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/present6.v
+++ b/theories/present6.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/present7.v
+++ b/theories/present7.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/present8.v
+++ b/theories/present8.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/present9.v
+++ b/theories/present9.v
@@ -1,10 +1,7 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrnat ssrint.
-From fourcolor
-Require Import part hubcap present.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat ssrint.
+From fourcolor Require Import part hubcap present.
 
 (******************************************************************************)
 (*   This file contains the unavoidability proof for cartwheels with a hub    *)

--- a/theories/quiz.v
+++ b/theories/quiz.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry coloring.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry coloring.
 
 (******************************************************************************)
 (*   A quiz is a pair of binary trees - questions - that covers the inner     *)

--- a/theories/quiztree.v
+++ b/theories/quiztree.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
-From mathcomp
-Require Import path fingraph.
-From fourcolor
-Require Import hypermap geometry color coloring quiz cfmap cfquiz cfreducible.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color coloring quiz cfmap.
+From fourcolor Require Import cfquiz cfreducible.
 
 (******************************************************************************)
 (*   Compile a sequence of (reducible) configurations into a set of quizzes,  *)
@@ -330,7 +327,7 @@ Proof. by case: qa t => [] // [] // []. Qed.
 End FitQuizTree.
 
 (*  global sanity check, using the functions defined above
-Require Import configurations.
+From fourcolor Require Import configurations.
 
 Eval compute in (qzt_size (cfquiz_tree the_configs)).
 Eval compute in (cf_qzt_size the_configs).

--- a/theories/realcategorical.v
+++ b/theories/realcategorical.v
@@ -1,11 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq order ssralg ssrnum ssrint rat.
-Require Import Morphisms Setoid.
-From fourcolor
-Require Import real realsyntax realprop.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq order.
+From mathcomp Require Import ssralg ssrnum ssrint rat.
+From Coq Require Import Morphisms Setoid.
+From fourcolor Require Import real realsyntax realprop.
 
 (******************************************************************************)
 (*   A proof that the real axiomatisation is categorical -- hence that our    *)

--- a/theories/realplane.v
+++ b/theories/realplane.v
@@ -1,7 +1,6 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-From fourcolor
-Require Import real.
+From fourcolor Require Import real.
 
 (******************************************************************************)
 (*  An elementary formalization of the real plane topology required to state  *)

--- a/theories/realprop.v
+++ b/theories/realprop.v
@@ -1,13 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat div order.
-From mathcomp
-Require Import ssralg ssrnum ssrint rat intdiv.
-Require Import Morphisms Setoid.
-From fourcolor
-Require Import real realsyntax.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat div order.
+From mathcomp Require Import ssralg ssrnum ssrint rat intdiv.
+From Coq Require Import Morphisms Setoid.
+From fourcolor Require Import real realsyntax.
 
 (******************************************************************************)
 (*   This file establishes basic arithmetic/order/setoid properties of the    *)

--- a/theories/redpart.v
+++ b/theories/redpart.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry part quiz quiztree.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry part quiz quiztree.
 
 (******************************************************************************)
 (*   Reducibility check for parts, that is, testing that every 2-neighborhood *)

--- a/theories/reducibility.v
+++ b/theories/reducibility.v
@@ -1,14 +1,11 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations present.
-From fourcolor
-Require Import task001to214 task215to234 task235to282 task283to302 task303to322.
-From fourcolor
-Require Import task323to485 task486to506 task507to541 task542to588 task589to633.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations present.
+From fourcolor Require Import task001to214 task215to234 task235to282.
+From fourcolor Require Import task283to302 task303to322 task323to485.
+From fourcolor Require Import task486to506 task507to541 task542to588.
+From fourcolor Require Import task589to633.
 
 (******************************************************************************)
 (*   C-reducibility of all the configurations in the_configs, collating the   *)

--- a/theories/revsnip.v
+++ b/theories/revsnip.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry patch sew snip color chromogram coloring.
-From fourcolor
-Require Import kempe.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry patch sew snip color chromogram.
+From fourcolor Require Import coloring kempe.
 
 (******************************************************************************)
 (*   Dissecting a connected plain map along a proper ring, and its reverse    *)

--- a/theories/sew.v
+++ b/theories/sew.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap geometry color patch.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap geometry color patch.
 
 (******************************************************************************)
 (*   This file provides the means for "sewing" two hypermaps Gd and Gr along  *)

--- a/theories/snip.v
+++ b/theories/snip.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap jordan color geometry patch.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap jordan color geometry patch.
 
 (******************************************************************************)
 (*   This file provides a construction for cutting a planar hypermmap G along *)

--- a/theories/task001to214.v
+++ b/theories/task001to214.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job001to106 job107to164 job165to189 job190to206 job207to214.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job001to106 job107to164 job165to189.
+From fourcolor Require Import job190to206 job207to214.
 
 (******************************************************************************)
 (* Reducibility of configurations number 1 to 214, whose indices in           *)

--- a/theories/task215to234.v
+++ b/theories/task215to234.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job215to218 job219to222 job223to226 job227to230 job231to234.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job215to218 job219to222 job223to226.
+From fourcolor Require Import job227to230 job231to234.
 
 (******************************************************************************)
 (* Reducibility of configurations number 215 to 234, whose indices in         *)

--- a/theories/task235to282.v
+++ b/theories/task235to282.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job235to238 job239to253 job254to270 job271to278 job279to282.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job235to238 job239to253 job254to270.
+From fourcolor Require Import job271to278 job279to282.
 
 (******************************************************************************)
 (* Reducibility of configurations number 235 to 282, whose indices in         *)

--- a/theories/task283to302.v
+++ b/theories/task283to302.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job283to286 job287to290 job291to294 job295to298 job299to302.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job283to286 job287to290 job291to294.
+From fourcolor Require Import job295to298 job299to302.
 
 (******************************************************************************)
 (* Reducibility of configurations number 283 to 302, whose indices in         *)

--- a/theories/task303to322.v
+++ b/theories/task303to322.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job303to306 job307to310 job311to314 job315to318 job319to322.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job303to306 job307to310 job311to314.
+From fourcolor Require Import job315to318 job319to322.
 
 (******************************************************************************)
 (* Reducibility of configurations number 303 to 322, whose indices in         *)

--- a/theories/task323to485.v
+++ b/theories/task323to485.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job323to383 job384to398 job399to438 job439to465 job466to485.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job323to383 job384to398 job399to438.
+From fourcolor Require Import job439to465 job466to485.
 
 (******************************************************************************)
 (* Reducibility of configurations number 323 to 485, whose indices in         *)

--- a/theories/task486to506.v
+++ b/theories/task486to506.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job486to489 job490to494 job495to498 job499to502 job503to506.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job486to489 job490to494 job495to498.
+From fourcolor Require Import job499to502 job503to506.
 
 (******************************************************************************)
 (* Reducibility of configurations number 486 to 506, whose indices in         *)

--- a/theories/task507to541.v
+++ b/theories/task507to541.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job507to510 job511to516 job517to530 job531to534 job535to541.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job507to510 job511to516 job517to530.
+From fourcolor Require Import job531to534 job535to541.
 
 (******************************************************************************)
 (* Reducibility of configurations number 507 to 541, whose indices in         *)

--- a/theories/task542to588.v
+++ b/theories/task542to588.v
@@ -1,12 +1,9 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job542to545 job546to549 job550to553 job554to562 job563to588.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job542to545 job546to549 job550to553.
+From fourcolor Require Import job554to562 job563to588.
 
 (******************************************************************************)
 (* Reducibility of configurations number 542 to 588, whose indices in         *)

--- a/theories/task589to633.v
+++ b/theories/task589to633.v
@@ -1,12 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrnat seq.
-From fourcolor
-Require Import cfmap cfreducible configurations.
-From fourcolor
-Require Import job589to610 job611to617 job618to622 job623to633.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq.
+From fourcolor Require Import cfmap cfreducible configurations.
+From fourcolor Require Import job589to610 job611to617 job618to622 job623to633.
 
 (******************************************************************************)
 (* Reducibility of configurations number 589 to 633, whose indices in         *)

--- a/theories/unavoidability.v
+++ b/theories/unavoidability.v
@@ -1,16 +1,11 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From mathcomp
-Require Import ssralg ssrnum ssrint.
-From fourcolor
-Require Import hypermap geometry coloring patch birkhoff part discharge.
-From fourcolor
-Require Import configurations hubcap present.
-From fourcolor
-Require Import present5 present6 present7 present8 present9 present10 present11.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph ssralg ssrnum ssrint.
+From fourcolor Require Import hypermap geometry coloring patch birkhoff part.
+From fourcolor Require Import discharge configurations hubcap present.
+From fourcolor Require Import present5 present6 present7 present8 present9.
+From fourcolor Require Import present10 present11.
 
 (******************************************************************************)
 (*   The main unavoidability theorem: reducibility implies no minimal counter *)

--- a/theories/walkup.v
+++ b/theories/walkup.v
@@ -1,10 +1,8 @@
 (* (c) Copyright 2006-2018 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype path fingraph.
-From fourcolor
-Require Import hypermap.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype path fingraph.
+From fourcolor Require Import hypermap.
 
 (******************************************************************************)
 (* The Walkup construction (as described by Stahl) removes a point from the   *)


### PR DESCRIPTION
As discussed on Zulip, we implement the following recommended heuristics for `Require Import` and MathComp:
- handle `ssreflect` as `From mathcomp Require Import ssreflect ...`
- never import `ssreflect` without `ssrfun` and `ssrbool`