### PR TITLE
`inE` robustness wrt math-comp/math-comp#863

### DIFF
--- a/theories/birkhoff.v
+++ b/theories/birkhoff.v
@@ -361,7 +361,7 @@ Lemma nontrivial_cycle2 (x y : G) (r := [:: x; y]) :
 Proof.
 move=> Ur y'ex; apply/nontrivial0P; split.
   exists (node x); rewrite !inE -(fclosed1 (diskN_node r)).
-  rewrite diskN_E inE /= mem_head unfold_in /= -{2}[x]nodeK -cface1r.
+  rewrite diskN_E mem_head unfold_in /= -{2}[x]nodeK -cface1r.
   rewrite bridgeless_cface //= orbF andbT; apply: contraL Ur => nxFy /=.
   rewrite /rlink -(same_connect_r cfaceC nxFy) -[node x]nodeK -cface1r.
   by rewrite cface1 -(canRL nodeK (nnn x)) bridgeless_cface.

--- a/theories/cfmap.v
+++ b/theories/cfmap.v
@@ -1338,12 +1338,12 @@ Lemma node_injcp cp1 cp2 :
   {in [predC cpring (cpmap cp2)], {morph @injcp cp1 cp2 : x / node x}}.
 Proof.
 elim: cp1 cp2 => [|[n||||||] cp1 IHcp] //= cp2 cp1ok x XN'x.
-- by rewrite IHcp // 2!inE cpring_ecpR mem_rot.
+- by rewrite IHcp // inE /= cpring_ecpR mem_rot.
 - rewrite -IHcp -1?icpY_node //; first rewrite !inE mem_cpring in XN'x.
     by rewrite !inE; apply: contra XN'x => /pred2P[]->; rewrite -?cnode1r.
-  rewrite 2!inE cpring_ecpY -/cpmap !inE (mem_map (@icpY_inj _ _)) !orFb.
+  rewrite inE /= cpring_ecpY -/cpmap !inE (mem_map (@icpY_inj _ _)) !orFb.
   by apply: contra XN'x; apply: mem_behead.
-- rewrite -IHcp -1?icpH_node //; first rewrite!inE mem_cpring in XN'x.
+- rewrite -IHcp -1?icpH_node //; first rewrite !inE mem_cpring in XN'x.
     rewrite !inE -/cpmap; apply: contra XN'x => /or3P.
     by case=> /eqP->; rewrite ?fconnect1 // cnode1r edgeK.
   rewrite cpring_ecpN cpring_ecpY -/cpmap; case: ifP => // _.

--- a/theories/cube.v
+++ b/theories/cube.v
@@ -124,9 +124,7 @@ by apply: (intro_closed qfC) => [[o x] v Dv]; rewrite -((_ =P v) Dv); case o.
 Qed.
 
 Let qFaQf : closed qf aQf.
-Proof.
-by move=> u v uFv; rewrite 3!inE /= [u \in _](qFaQe uFv) [u \in _](qFaQn uFv).
-Qed.
+Proof. by move=> u v uFv; congr (~~ (_ || _)); [apply/qFaQe|apply/qFaQn]. Qed.
 
 Let qfAe : fun_adjunction (tsI CTe) cube_face edge aQe.
 Proof.

--- a/theories/gridmap.v
+++ b/theories/gridmap.v
@@ -158,7 +158,7 @@ have: cm_proper xcm.
 apply: IHn => [|f i bf m xcm'f].
   move: le_cm_n; rewrite ltnS (cardD1 e) inE [_ && _]cm'e.
   apply/leq_ltn_trans/subset_leq_card/subsetP=> f xcm'f.
-  by rewrite inE xcm'cm' // (memPn _ _ xcm'f).
+  by rewrite inE /= [f \in _]xcm'cm' // (memPn _ _ xcm'f).
 have bf'e p: ab e p -> ~ bf p by move=> ? /(abP e)D; rewrite D ?xcm'f in xcm_e.
 have /xcm'cm'/(abcmP f i)/= := xcm'f; rewrite -/bf /m /=.
 case: eqP => // -> -[e2bf bf_f]; split=> [/e2bf[cm2ref_bf cm2_bf]|]; last first.

--- a/theories/hubcap.v
+++ b/theories/hubcap.v
@@ -382,7 +382,7 @@ pose b (y : G) m := (dbound2 rt0 rs0 y *+ m)%R.
 pose db2 w y (i := findex face x1 y) (w_i := nth 0 w i) (v_i := nth 0 v i) :=
   b y (if w_i > 1 then 2 else if w_i < 1 then 0 else (v_i == 1).+1).
 pose sum_db2 w := (\sum_(y in cface x1) db2 w y)%R.
-have{v'0} db2v: {in cface x1, forall y1, db2 v y1 = b y1 2%N}%R.
+have{v'0} db2v: {in cface x1, forall y1, db2 v y1 = b y1 2}.
   move=> y x1Fy; congr (_ *+ _)%R; set i := findex face x1 y.
   have ltin: i < nhub by rewrite -nFx1 findex_max.
   by case: ltngtP; rewrite // ltnNge lt0n (memPn v'0) ?mem_nth ?Ev.

--- a/theories/patch.v
+++ b/theories/patch.v
@@ -336,7 +336,7 @@ Let oaGr : n_comp glink Gr = n_comp glink a.
 Proof.
 have [cG cGr] := (@glinkC G, @glinkC Gr).
 rewrite (adjunction_n_comp hr cG cGr clGa).
-  by apply: eq_card => xr; congr (_ && _); rewrite 5!inE mem_closure ?codom_f.
+  by apply: eq_card => xr; congr (_ && _); apply/esym/mem_closure/codom_f.
 split=> [x a_x | xr zr _].
   apply: sigW; have [y /= yGx /imageP[yr _ Dy]] := exists_inP a_x.
   by exists yr; rewrite -Dy.

--- a/theories/snip.v
+++ b/theories/snip.v
@@ -97,9 +97,9 @@ have [z rz z'Dx] := hasP dNx; exists z => //.
 by apply: connect_trans z'Dx (connect1 _); rewrite /dlink /= rx /clink /= eqxx.
 Qed.
 
-Lemma diskN_E : diskN =i [predU r & diskE].
+Lemma diskN_E x : (x \in diskN) = (x \in r) || (x \in diskE).
 Proof.
-move=> x; rewrite !inE; case r_x: (x \in r) => //=.
+rewrite !inE; case r_x: (x \in r) => //=.
 rewrite -[x](f_finv nodeI) -(fclosed1 diskN_node).
 by apply/hasP; exists x; last apply: connect0.
 Qed.
@@ -259,7 +259,7 @@ Definition snipd_edge x := if x \in r then next r x else edge x.
 
 Fact dedge_subproof (u : ddart) : snipd_edge (val u) \in diskN.
 Proof.
-rewrite /= /snipd_edge diskN_E inE /=.
+rewrite /= /snipd_edge diskN_E.
 case ru: (val u \in r); first by rewrite mem_next ru.
 by rewrite orbC -(fclosed1 diskE_edge) inE /= ru (valP u).
 Qed.
@@ -268,7 +268,7 @@ Definition snipd_face x := if x \in r then face (edge (prev r x)) else face x.
 
 Fact dface_subproof  (u : ddart) : snipd_face (val u) \in diskN.
 Proof.
-rewrite /= /snipd_face (fclosed1 diskN_node) diskN_E inE /=.
+rewrite /= /snipd_face (fclosed1 diskN_node) diskN_E.
 case ru: (val u \in r); first by rewrite edgeK mem_prev ru.
 by rewrite orbC (fclosed1 diskE_edge) faceK inE /= ru (valP u).
 Qed.
@@ -331,7 +331,7 @@ have homFd' u v :
     apply: contra b'u => ru; apply/hasP; exists u => //.
     by rewrite -(mem_map inj_snipd) map_snipd_ring.
   have dNy: y \in diskN.
-    rewrite (fclosed1 diskN_node) diskN_E inE /= (fclosed1 diskE_edge) orbC.
+    rewrite (fclosed1 diskN_node) diskN_E (fclosed1 diskE_edge) orbC.
     by rewrite -Dy faceK inE /= r'u (valP u).
   apply: connect_trans {IHp yFp Lp}(IHp (Sub y _) _ yFp Lp).
     by rewrite connect1 //= -val_eqE /= /snipd_face (negPf r'u) Dy.


### PR DESCRIPTION
Improve proof script robustness whereby selective rewriting depended on that `inE` expands `x \in A, when `A` is one of the collective `pred`combinators (e.g., `[predU _ & _ ]`), into an expression involving `pred_of_simpl (mem ..) x` subexpression, which need to be further simplified using `/=` or `inE`.
  This will no longer be necessary with future versions of `ssrbool.v`, so this PR removes various hacks that depended on this behavior, such as using explicit  `3!inE` repeat counts.
  As part of this we inlined the `[predU _]` notation in the statement of the `diskN_E` lemma, since expanding it after using the lemma was awkward without the above hacks.