### PR TITLE
avoid using disabled mathcomp docker images in CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -30,9 +30,6 @@ jobs:
           - 'mathcomp/mathcomp:1.15.0-coq-8.14'
           - 'mathcomp/mathcomp:1.15.0-coq-8.15'
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
-          - 'mathcomp/mathcomp-dev:coq-8.14'
-          - 'mathcomp/mathcomp-dev:coq-8.15'
-          - 'mathcomp/mathcomp-dev:coq-8.16'
           - 'coqorg/coq:dev'
       fail-fast: false
     steps:

--- a/meta.yml
+++ b/meta.yml
@@ -60,12 +60,6 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.15.0-coq-8.16'
   repo: 'mathcomp/mathcomp'
-- version: 'coq-8.14'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.15'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.16'
-  repo: 'mathcomp/mathcomp-dev'
 - version: 'dev'
 
 # test master every day at 05:00 UTC


### PR DESCRIPTION
MathComp's dev-related Docker images have been temporarily disabled, so we remove them from CI (to add back later).