### PR TITLE
use MathComp dev Docker image again

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -30,14 +30,15 @@ jobs:
           - 'mathcomp/mathcomp:1.15.0-coq-8.14'
           - 'mathcomp/mathcomp:1.15.0-coq-8.15'
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
-          - 'coqorg/coq:dev'
+          - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-fourcolor.opam'
           custom_image: ${{ matrix.image }}
+
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/meta.yml
+++ b/meta.yml
@@ -60,7 +60,8 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.15.0-coq-8.16'
   repo: 'mathcomp/mathcomp'
-- version: 'dev'
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 
 # test master every day at 05:00 UTC
 # (mathcomp/mathcomp-dev is rebuilt every day at 04:00 Paris time)


### PR DESCRIPTION
MathComp Docker images are building again, so reactivate with latest boilerplate.