### PR TITLE
Adapt to Coq PR #18591: better refolding of addn induces now useless addnE

### DIFF
--- a/theories/initctree.v
+++ b/theories/initctree.v
@@ -105,7 +105,7 @@ Lemma ctree_add_dyck_leaf_of m n d :
 Proof.
 elim: n m d => [|n IHn] m /=; first by rewrite addn0 gen_dyck_all_close.
 elim: m => [|m IHm] d; rewrite doubleS /=; first by rewrite addn0 IHn.
-by rewrite IHm IHn doubleS addnA -addnE !addnS.
+by rewrite IHm IHn doubleS addnA -?addnE !addnS.
 Qed.
 
 Lemma ctree_leaf_table_size h : size (ctree_leaf_table h) = h.+1.


### PR DESCRIPTION
The tactic `simpl` was missing some refoldings that Coq's PR coq/coq#18591 fixes. As a result, a rewriting from `Nat.add` to `addn` becomes useless. We keep it optional though for compatibility (though I did not double-check the compilation myself). If correctly backwards-compatible, it can be merged as soon as now.