### PR TITLE
switch Docker CI cron to weekly, explicit dependency on HB

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -4,7 +4,7 @@ name: Docker CI
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 5 * * 0'
   push:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ basic plane topology definitions, and a theory of combinatorial hypermaps.
 - License: [CeCILL-B](LICENSE)
 - Compatible Coq versions: 8.16 or later
 - Additional dependencies:
-  - [MathComp ssreflect 2.1 or later](https://math-comp.github.io)
+  - [MathComp ssreflect 2.1.0 or later](https://math-comp.github.io)
   - [MathComp algebra](https://math-comp.github.io)
+  - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.5.0 or later
 - Coq namespace: `fourcolor`
 - Related publication(s):
   - [Formal Proof—The Four-Color Theorem](https://www.ams.org/notices/200811/tx081101382p.pdf) 

--- a/coq-fourcolor.opam
+++ b/coq-fourcolor.opam
@@ -20,9 +20,10 @@ basic plane topology definitions, and a theory of combinatorial hypermaps."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16" & < "8.20~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.3~") | (= "dev")}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.1.0"}
   "coq-mathcomp-algebra" 
+  "coq-hierarchy-builder" {>= "1.5.0"}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -37,7 +37,7 @@ license:
 
 supported_coq_versions:
   text: 8.16 or later
-  opam: '{(>= "8.16" & < "8.20~") | (= "dev")}'
+  opam: '{>= "8.16"}'
 
 tested_coq_opam_versions:
 - version: '2.1.0-coq-8.16'
@@ -55,20 +55,25 @@ tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
 
-# test master every day at 05:00 UTC
+# test master every Sunday at 05:00 UTC
 # (mathcomp/mathcomp-dev is rebuilt every day at 04:00 Paris time)
-ci_cron_schedule: '0 5 * * *'
+ci_cron_schedule: '0 5 * * 0'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "2.1.0" & < "2.3~") | (= "dev")}'
+    version: '{>= "2.1.0"}'
   description: |-
-    [MathComp ssreflect 2.1 or later](https://math-comp.github.io)
+    [MathComp ssreflect 2.1.0 or later](https://math-comp.github.io)
 - opam:
     name: coq-mathcomp-algebra
   description: |-
     [MathComp algebra](https://math-comp.github.io)
+- opam:
+    name: coq-hierarchy-builder
+    version: '{>= "1.5.0"}'
+  description: |-
+    [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.5.0 or later
 
 namespace: fourcolor
 


### PR DESCRIPTION
We've started hitting Docker pull rate limits [here](https://github.com/coq-community/fourcolor/actions/runs/10070889574/job/27840150955):
> Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit

Since fourcolor is already tested in MathComp's CI using Nix, this PR restricts the recurring Docker cron CI to once per week. This should reduce the number of Docker pulls so we don't hit the limit.

At the same time, I explicitly record Hierarchy Builder as a dependency, since there are plenty of `From HB Require Import structures` in the code, and adjust some opam boundaries to require less maintenance.