### PR TITLE
Adapt to mc#1300

### DIFF
--- a/theories/proof/hypermap.v
+++ b/theories/proof/hypermap.v
@@ -430,6 +430,8 @@ Qed.
 
 End DerivedMaps.
 
+Arguments cface_mirror [G] x y.
+
 Section EqualHypermap.
 
 Variable G : hypermap.


### PR DESCRIPTION
https://github.com/math-comp/math-comp/pull/1300 generalizes `eqrel` to dependent functions, so in `(f =2 g) x y`, `x` is now implicit.